### PR TITLE
Fix markdown in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,8 +278,8 @@ Install test requirements:
 
 Create database:
 
-
 .. code-block:: shell
+
     cd tests/
     ./manage.py migrate
     ./manage.py createsuperuser


### PR DESCRIPTION
Markdown for paragraph `Create database:` was broken.